### PR TITLE
Create basic Cloud Connect GCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,71 @@
 # terraform-cloud-connect
 
-## Description
+The main purpose of these scripts is to create the necessary resources and permissions to get you started with Bitmovin Cloud Connect.
 
-The main purpose of this script is to create an IAM User with enough permission and a Security Group with correct Inbound and Outbound rules so that Bitmovin's Cloud Connect product will be able to run Video Encodings in the configured infrastructure.
+## What's inside?
 
-The Terraform Cloud Connect module does the following:
+### AWS
 
-- Creates new IAM user
-- Assigns required permission for Cloud-Connect: approx. AmazonEC2FullAccess
+The AWS module will create the following resources to enable running encoding jobs with Bitmovin Cloud Connect:
+
+- Creates a new IAM user
+- Assigns the required permission for Cloud-Connect: approx. `AmazonEC2FullAccess`
 - Creates a Security Group
-- Adds required Inbound and Outbound rules
+- Adds the required Inbound and Outbound rules
 - Outputs:
-    - Account Id
-    - Access Key
-    - Secret Access Key
-    - Security Group Id
+  - Account Id
+  - Access Key
+  - Secret Access Key
+  - Security Group Id
 
 The outputs that are produced by the script can be used in a next step to configure the [Bitmovin Encoder for Cloud Connect](https://developer.bitmovin.com/encoding/docs/using-bitmovin-cloud-connect-with-aws#configure-your-bitmovin-account).
+
+### GCP
+
+The GCP module will create the following resources to enable running encoding jobs with Bitmovin Cloud Connect:
+
+- Enable the Compute Engine API
+- Creates a new Service Account
+  - with the permissions of role `roles/compute.instanceAdmin.v1`
+  - with an Access Key
+- Creates a new auto-mode VPC network
+- Creates the required firewall rules
+- Outputs:
+  - Project ID
+  - Service Account Email
+  - Private Key (instructions)
+  - Network ID
+  - Subnet ID instructions
 
 ## Provider
 
 **Important**
-- The script currently supports only one provider and one region at a time. 
-- Please specify the desired region where you expect your encodings to run. 
-- Additionally, provide the roles that may grant account creation rights for the specified provider.
+
+- The script currently supports only one provider and one region at a time.
+- (AWS only) Please specify the desired region where you expect your encodings to run.
+- (AWS only) Additionally, provide the roles that may grant account creation rights for the specified provider.
 
 ## Usage
 
-Install Terraform: 
+Install Terraform and the provider of your choice:
 
-https://developer.hashicorp.com/terraform/install
+- Terraform https://developer.hashicorp.com/terraform/install
+- provider of your choice
+  - AWS https://developer.hashicorp.com/terraform/tutorials/aws-get-started/aws-build
+  - GCP https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/google-cloud-platform-build
 
 Run:
 
-````
+```
 terraform init
 terraform plan
 terraform apply
-````
+```
 
 You can use the Bitmovin Cloud Connect Terraform module like this:
 
-````
+```terraform
+# examples/aws/main.tf
 provider "aws" {
   region   = "eu-west-1"
   assume_role {
@@ -52,62 +76,60 @@ provider "aws" {
 module "bitmovin_cloud_connect" {
   source  = "github.com/bitmovin/terraform-cloud-connect/modules/aws"
 }
-````
+```
 
 For all possible configurations, please check [Inputs](#inputs).
 
-Based on [Bitmovin Cloud Connect Configuration](https://developer.bitmovin.com/encoding/docs/using-bitmovin-cloud-connect-with-aws#configure-your-bitmovin-account), we need the following output:
+Based on the selected provider module, the script will output different information. This information is relevant to connect your infrastructure with Bitmovin Cloud Connect:
 
-````
-output "account_id" {
-  value = module.bitmovin_cloud_connect.account_id
-}
-
-output "access_key" {
-  value = module.bitmovin_cloud_connect.access_key
-}
-
-output "secret_access_key" {
-  value     = module.bitmovin_cloud_connect.secret_access_key
-  sensitive = true
-}
-
-output "security_group_id" {
-  value = module.bitmovin_cloud_connect.security_group_id
-}
-````
+- [Configure your Bitmovin account with AWS](https://developer.bitmovin.com/encoding/docs/using-bitmovin-cloud-connect-with-aws#configure-your-bitmovin-account)
+- [Configure your Bitmovin account with GCP](https://developer.bitmovin.com/encoding/docs/using-bitmovin-cloud-connect-with-gcp#configure-your-bitmovin-account)
 
 Print out the outputs:
 
-````
+```
 terraform output -json
-````
+```
 
 Remove the created resources with the following commands:
 
-````
+```
 terraform destroy
-````
+```
 
-**Warning**: using the above command will remove the user, policy, security group and rules needed for the Bitmovin Cloud Connect product to work. Use the destroy command when you want to stop using the previously created resources.
+**Warning**: using the command above will remove the created Terraform-managed resources for Bitmovin Cloud Connect to work. Use the `destroy` command only when you are sure you want to stop using the previously created resources.
 
 ## Inputs
 
-| Input        | Description           | Type  | Default  |
-| :------------|:----------------------|:------|:---------|
-| user_name | Name of the IAM user that will be created | string | "bitmovin-cloud-connect"|
-| policy_name | Name of the Policy that will be created | string | "bitmovin-cloud-connect" |
-| security_group_name | Name of the Security Group that will be created | string | "bitmovin-cloud-connect" |
-| | | | |
-| live_rtmp | Prepare live RTMP by setting the correct ingress rules | bool | false |
-| live_srt | Prepare live SRT by setting the correct ingress rules | bool | false |
-| live_zixi | Prepare live Zixi by setting the correct ingress rules | bool | false |
-| | | | |
-| live_ingress_ipv4_network_blocks | Allowed ingress IPv4 used for live (RTMP, SRT, Zixi) | list(string) | ["0.0.0.0/0"] |
-| live_ingress_ipv6_network_blocks | Allowed ingress IPv6 used for live (RTMP, SRT, Zixi) | list(string) | ["::/0"] |
-| | | | |
-| tags | Tags that will be attached to the created resources | map | { company = "bitmovin", product = "cloud-connect" } |
+## All providers
+
+| Input                            | Description                                            | Type         | Default       |
+| :------------------------------- | :----------------------------------------------------- | :----------- | :------------ |
+| live_rtmp                        | Prepare live RTMP by setting the correct ingress rules | bool         | false         |
+| live_srt                         | Prepare live SRT by setting the correct ingress rules  | bool         | false         |
+| live_zixi                        | Prepare live Zixi by setting the correct ingress rules | bool         | false         |
+| live_ingress_ipv4_network_blocks | Allowed ingress IPv4 used for live (RTMP, SRT, Zixi)   | list(string) | ["0.0.0.0/0"] |
+| live_ingress_ipv6_network_blocks | Allowed ingress IPv6 used for live (RTMP, SRT, Zixi)   | list(string) | ["::/0"]      |
+
+## AWS-only
+
+| Input               | Description                                         | Type   | Default                                             |
+| :------------------ | :-------------------------------------------------- | :----- | :-------------------------------------------------- |
+| user_name           | Name of the IAM user that will be created           | string | "bitmovin-cloud-connect"                            |
+| policy_name         | Name of the Policy that will be created             | string | "bitmovin-cloud-connect"                            |
+| security_group_name | Name of the Security Group that will be created     | string | "bitmovin-cloud-connect"                            |
+| tags                | Tags that will be attached to the created resources | map    | { company = "bitmovin", product = "cloud-connect" } |
+
+## GCP-only
+
+| Input                 | Description                                                       | Type   | Default                       |
+| :-------------------- | :---------------------------------------------------------------- | :----- | :---------------------------- |
+| project_id (required) | Project ID of the Bitmovin project for Cloud Connect Encoding     | string |                               |
+| account_id            | Account ID of the Service Account user for Cloud Connect Encoding | string | "bitmovin-cloud-connect-user" |
+| user_name             | Name of the Service Account user for Cloud Connect Encoding       | string | "bitmovin-cloud-connect-user" |
+| network_name          | Auto-mode VPC network for Cloud Connect Encoding                  | string | "bitmovin-cloud-connect"      |
 
 ## Examples
 
-[AWS Example](https://github.com/bitmovin/terraform-cloud-connect/tree/main/examples/aws) - Use Bitmovin AWS Cloud Connect.
+- [Use Bitmovin Cloud Connect with AWS](https://github.com/bitmovin/terraform-cloud-connect/tree/main/examples/aws)
+- [Use Bitmovin Cloud Connect with GCP](https://github.com/bitmovin/terraform-cloud-connect/tree/main/examples/gcp)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Install Terraform and the provider of your choice:
 
 Run:
 
-```
+```sh
 terraform init
 terraform plan
 terraform apply
@@ -103,13 +103,13 @@ Based on the selected provider module, the script will output different informat
 
 Print out the outputs:
 
-```
+```sh
 terraform output -json
 ```
 
 Remove the created resources with the following commands:
 
-```
+```sh
 terraform destroy
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,23 @@ provider "aws" {
 }
 
 module "bitmovin_cloud_connect" {
-  source  = "github.com/bitmovin/terraform-cloud-connect/modules/aws"
+  source  = "github.com/bitmovin/terraform-cloud-connect/blob/main/modules/aws"
+}
+```
+
+```terraform
+# examples/gcp/main.tf
+locals {
+  project_id = "your GCP Project ID"
+}
+
+provider "google" {
+  project = local.project_id
+}
+
+module "bitmovin_cloud_connect" {
+  project_id = local.project_id
+  source     = "github.com/bitmovin/terraform-cloud-connect/blob/main/modules/gcp"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The outputs that are produced by the script can be used in a next step to config
 
 The GCP module will create the following resources to enable running encoding jobs with Bitmovin Cloud Connect:
 
-- Enable the Compute Engine API
+- Enables the Compute Engine API
 - Creates a new Service Account
   - with the permissions of role `roles/compute.instanceAdmin.v1`
   - with an Access Key
@@ -119,7 +119,7 @@ terraform destroy
 
 ## Inputs
 
-## All providers
+### All providers
 
 | Input                            | Description                                            | Type         | Default       |
 | :------------------------------- | :----------------------------------------------------- | :----------- | :------------ |
@@ -129,7 +129,7 @@ terraform destroy
 | live_ingress_ipv4_network_blocks | Allowed ingress IPv4 used for live (RTMP, SRT, Zixi)   | list(string) | ["0.0.0.0/0"] |
 | live_ingress_ipv6_network_blocks | Allowed ingress IPv6 used for live (RTMP, SRT, Zixi)   | list(string) | ["::/0"]      |
 
-## AWS-only
+### AWS-only
 
 | Input               | Description                                         | Type   | Default                                             |
 | :------------------ | :-------------------------------------------------- | :----- | :-------------------------------------------------- |
@@ -138,7 +138,7 @@ terraform destroy
 | security_group_name | Name of the Security Group that will be created     | string | "bitmovin-cloud-connect"                            |
 | tags                | Tags that will be attached to the created resources | map    | { company = "bitmovin", product = "cloud-connect" } |
 
-## GCP-only
+### GCP-only
 
 | Input                 | Description                                                       | Type   | Default                       |
 | :-------------------- | :---------------------------------------------------------------- | :----- | :---------------------------- |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The GCP module will create the following resources to enable running encoding jo
   - Network ID
   - Subnet ID instructions
 
+The outputs that are produced by the script can be used in a next step to configure the [Bitmovin Encoder for Cloud Connect](https://developer.bitmovin.com/encoding/docs/using-bitmovin-cloud-connect-with-gcp#configure-your-bitmovin-account).
+
 ## Provider
 
 **Important**

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "bitmovin_cloud_connect" {
-  source  = "github.com/bitmovin/terraform-cloud-connect//modules/aws"
+  source = "github.com/bitmovin/terraform-cloud-connect/blob/main/modules/aws"
 
   # For all possible input variables, please check:
   # Documentation: https://github.com/bitmovin/terraform-cloud-connect/blob/main/README.md#inputs

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -1,0 +1,15 @@
+locals {
+  project_id = "{{YOUR_PROJECT_ID}}"
+}
+
+provider "google" {
+  project = local.project_id
+}
+
+module "bitmovin_cloud_connect" {
+  project_id = local.project_id
+  source     = "../../modules/gcp"
+
+  # For all possible input variables, please check:
+  # Documentation: https://github.com/bitmovin/terraform-cloud-connect/blob/main/README.md#inputs
+}

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -8,7 +8,8 @@ provider "google" {
 
 module "bitmovin_cloud_connect" {
   project_id = local.project_id
-  source     = "../../modules/gcp"
+  source     = "../../modules/gcp" # local reference when you clone the repository
+  # source     = "github.com/bitmovin/terraform-cloud-connect/blob/main/modules/gcp" # remote GitHub reference
 
   # For all possible input variables, please check:
   # Documentation: https://github.com/bitmovin/terraform-cloud-connect/blob/main/README.md#inputs

--- a/examples/gcp/outputs.tf
+++ b/examples/gcp/outputs.tf
@@ -1,0 +1,25 @@
+output "project_id" {
+  value = module.bitmovin_cloud_connect.project_id
+}
+
+output "service_account_email" {
+  value = module.bitmovin_cloud_connect.service_account_email
+}
+
+output "private_key" {
+  value     = module.bitmovin_cloud_connect.private_key
+  sensitive = true
+}
+
+# output a message guiding users on handling the private key securely
+output "private_key_instructions" {
+  value = "The see your private key, run `terraform output -json`. Handle credentials carefully."
+}
+
+output "network_id" {
+  value = module.bitmovin_cloud_connect.network_id
+}
+
+output "subnet_id_instructions" {
+  value = "The find your region's subnet id, please go to https://console.cloud.google.com/networking/networks/list"
+}

--- a/examples/gcp/outputs.tf
+++ b/examples/gcp/outputs.tf
@@ -13,7 +13,7 @@ output "private_key" {
 
 # output a message guiding users on handling the private key securely
 output "private_key_instructions" {
-  value = "The see your private key, run `terraform output -json`. Handle credentials carefully."
+  value = "To see your private key, run `terraform output -json`. Handle credentials carefully."
 }
 
 output "network_id" {
@@ -21,5 +21,5 @@ output "network_id" {
 }
 
 output "subnet_id_instructions" {
-  value = "The find your region's subnet id, please go to https://console.cloud.google.com/networking/networks/list"
+  value = "To find your region's subnet id, please go to https://console.cloud.google.com/networking/networks/list"
 }

--- a/examples/gcp/terraform.tf
+++ b/examples/gcp/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "5.35.0"
+    }
+  }
+}

--- a/examples/gcp/terraform.tf
+++ b/examples/gcp/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.35.0"
+      version = "~> 5.35"
     }
   }
 }

--- a/modules/aws/rules.tf
+++ b/modules/aws/rules.tf
@@ -67,7 +67,7 @@ resource "aws_security_group_rule" "encoding_service_https_ingress_rule" {
 }
 
 resource "aws_security_group_rule" "incoming_commands_ingress_rule" {
-  description = "For incoming commands from the bitmovin API to control the encoding"
+  description = "For incoming commands from the BSitmovin API to control the encoding"
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress

--- a/modules/aws/rules.tf
+++ b/modules/aws/rules.tf
@@ -1,49 +1,49 @@
 locals {
   ingress = "ingress"
-  egress = "egress"
+  egress  = "egress"
 
-  all_ports = 0
-  ssh_port = 22
-  rtmp_port = 1935
-  rtmps_port = 443
-  zixi_port = 4444
-  encoding_port = 9999
+  all_ports           = 0
+  ssh_port            = 22
+  rtmp_port           = 1935
+  rtmps_port          = 443
+  zixi_port           = 4444
+  encoding_port       = 9999
   encoding_port_https = 9443
 
   all_protocols = "-1"
-  tcp = "tcp"
-  udp = "udp"
+  tcp           = "tcp"
+  udp           = "udp"
 
-  all_ipv4_network_blocks = ["0.0.0.0/0"]
-  all_ipv6_network_blocks = ["::/0"]
+  all_ipv4_network_blocks        = ["0.0.0.0/0"]
+  all_ipv6_network_blocks        = ["::/0"]
   bitmovin_static_network_blocks = ["104.199.97.13/32", "35.205.157.162/32"]
-  
+
   srt_ingress_rules = [
     { protocol = local.tcp, port = 2088 },
     { protocol = local.udp, port = 2088 },
     { protocol = local.tcp, port = 2089 },
     { protocol = local.tcp, port = 2090 },
     { protocol = local.tcp, port = 2091 },
-    ]
-    
+  ]
+
   live_ipv4_network_blocks = can(var.live_ingress_ipv4_network_blocks) || !can(var.live_ingress_ipv6_network_blocks) ? var.live_ingress_ipv4_network_blocks : null
   live_ipv6_network_blocks = can(var.live_ingress_ipv6_network_blocks) || !can(var.live_ingress_ipv4_network_blocks) ? var.live_ingress_ipv6_network_blocks : null
 }
 
 resource "aws_security_group_rule" "all_traffic_within_ingress_rule" {
-  description = "Allow communication between the main VM instance and the worker VM instances"
-  
+  description = "For communication between the session manager VM instance and its instance manager VM instances"
+
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
 
-  from_port   = local.all_ports
-  to_port     = local.all_ports
-  protocol    = local.all_protocols
-  self        = true
+  from_port = local.all_ports
+  to_port   = local.all_ports
+  protocol  = local.all_protocols
+  self      = true
 }
 
 resource "aws_security_group_rule" "encoding_service_ingress_rule" {
-  description = "Allow communication with the service that manages the encoding"
+  description = "For communication with the service that manages the encoding"
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
@@ -55,7 +55,7 @@ resource "aws_security_group_rule" "encoding_service_ingress_rule" {
 }
 
 resource "aws_security_group_rule" "encoding_service_https_ingress_rule" {
-  description = "Allow HTTPS communication with the service that manages the encoding"
+  description = "For HTTPS communication with the service that manages the encoding"
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
@@ -67,7 +67,7 @@ resource "aws_security_group_rule" "encoding_service_https_ingress_rule" {
 }
 
 resource "aws_security_group_rule" "incoming_commands_ingress_rule" {
-  description = "Allow incoming docker commands (i.e. pulling and starting docker containers)"
+  description = "For incoming commands from the bitmovin API to control the encoding"
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
@@ -91,62 +91,62 @@ resource "aws_security_group_rule" "all_traffic_egress_rule" {
 }
 
 resource "aws_security_group_rule" "live_rtmp_ingress_rule" {
-  description = "Allow RTMP live streams"
+  description = "For RTMP live streams"
 
   count = var.live_rtmp ? 1 : 0
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
 
-  from_port   = local.rtmp_port
-  to_port     = local.rtmp_port
-  protocol    = local.tcp
-  cidr_blocks = local.live_ipv4_network_blocks
+  from_port        = local.rtmp_port
+  to_port          = local.rtmp_port
+  protocol         = local.tcp
+  cidr_blocks      = local.live_ipv4_network_blocks
   ipv6_cidr_blocks = local.live_ipv6_network_blocks
 }
 
 resource "aws_security_group_rule" "live_rtmps_ingress_rule" {
-  description = "Allow RTMPS live streams"
+  description = "For RTMPS live streams"
 
   count = var.live_rtmp ? 1 : 0
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
 
-  from_port   = local.rtmps_port
-  to_port     = local.rtmps_port
-  protocol    = local.tcp
-  cidr_blocks = local.live_ipv4_network_blocks
+  from_port        = local.rtmps_port
+  to_port          = local.rtmps_port
+  protocol         = local.tcp
+  cidr_blocks      = local.live_ipv4_network_blocks
   ipv6_cidr_blocks = local.live_ipv6_network_blocks
 }
 
 resource "aws_security_group_rule" "live_srt_ingress_rule" {
-  description = "Allow SRT live streams"
+  description = "For SRT live streams"
 
   count = var.live_srt ? length(local.srt_ingress_rules) : 0
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
 
-  from_port   = local.srt_ingress_rules[count.index].port
-  to_port     = local.srt_ingress_rules[count.index].port
-  protocol    = local.srt_ingress_rules[count.index].protocol
+  from_port = local.srt_ingress_rules[count.index].port
+  to_port   = local.srt_ingress_rules[count.index].port
+  protocol  = local.srt_ingress_rules[count.index].protocol
 
-  cidr_blocks = local.live_ipv4_network_blocks
+  cidr_blocks      = local.live_ipv4_network_blocks
   ipv6_cidr_blocks = local.live_ipv6_network_blocks
 }
 
 resource "aws_security_group_rule" "live_zixi_ingress_rule" {
-  description = "Allow Zixi live streams"
+  description = "For Zixi live streams"
 
   count = var.live_zixi ? 1 : 0
 
   security_group_id = aws_security_group.security_group.id
   type              = local.ingress
 
-  from_port   = local.zixi_port
-  to_port     = local.zixi_port
-  protocol    = local.tcp
-  cidr_blocks = local.live_ipv4_network_blocks
+  from_port        = local.zixi_port
+  to_port          = local.zixi_port
+  protocol         = local.tcp
+  cidr_blocks      = local.live_ipv4_network_blocks
   ipv6_cidr_blocks = local.live_ipv6_network_blocks
 }

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -1,0 +1,30 @@
+data "google_project" "bitmovin_project" {}
+
+output "project_id" {
+  value = data.google_project.bitmovin_project.id
+}
+
+data "google_compute_network" "bitmovin_network" {
+  name = var.network_name
+}
+
+output "network_id" {
+  value = data.google_compute_network.bitmovin_network.name
+}
+
+data "google_service_account" "bitmovin_account" {
+  account_id = var.account_id
+}
+
+output "service_account_email" {
+  value = data.google_service_account.bitmovin_account.email
+}
+
+data "google_service_account_key" "mykey" {
+  name = google_service_account_key.mykey.name
+}
+
+output "private_key" {
+  value     = data.google_service_account_key.mykey
+  sensitive = true
+}

--- a/modules/gcp/rules.tf
+++ b/modules/gcp/rules.tf
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "bitmovin_allow_internal" {
 }
 
 resource "google_compute_firewall" "bitmovin_allow_ssh" {
-  description   = "For incoming commands (i.e. pulling and starting docker containers)"
+  description   = "For incoming commands from the bitmovin API to control the encoding"
   name          = "${google_compute_network.bitmovin_vpc_network.name}-allow-ssh"
   network       = google_compute_network.bitmovin_vpc_network.name
   source_ranges = local.bitmovin_static_network_blocks

--- a/modules/gcp/rules.tf
+++ b/modules/gcp/rules.tf
@@ -1,0 +1,135 @@
+locals {
+  internal_network_blocks        = ["10.0.0.0/8"]
+  bitmovin_static_network_blocks = ["104.199.97.13/32", "35.205.157.162/32"]
+}
+
+# enable Compute Engine API
+resource "google_project_service" "compute-engine" {
+  project = var.project_id
+  service = "compute.googleapis.com"
+}
+
+# create auto-mode VPC
+resource "google_compute_network" "bitmovin_vpc_network" {
+  name = var.network_name
+
+  depends_on = [google_project_service.compute-engine]
+}
+
+resource "google_compute_firewall" "bitmovin_allow_internal" {
+  description   = "For communication between the session manager VM instance and its instance manager VM instances"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-allow-internal"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = local.internal_network_blocks
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+}
+
+resource "google_compute_firewall" "bitmovin_allow_ssh" {
+  description   = "For incoming commands (i.e. pulling and starting docker containers)"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-allow-ssh"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = local.bitmovin_static_network_blocks
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_firewall" "bitmovin_encoder_service" {
+  description   = "For communication with the service that manages the encoding"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-encoder-service"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = local.bitmovin_static_network_blocks
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9999"]
+  }
+}
+
+resource "google_compute_firewall" "bitmovin_encoder_service_https" {
+  description   = "For HTTPS communication with the service that manages the encoding"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-encoder-service-https"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = local.bitmovin_static_network_blocks
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9443"]
+  }
+}
+
+resource "google_compute_firewall" "bitmovin_rtmp_listener" {
+  count = var.live_rtmp ? 1 : 0
+
+  description   = "For RTMP live streams"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-rtmp-listener"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = var.live_ingress_ipv4_network_blocks
+
+  allow {
+    protocol = "tcp"
+    ports    = ["1935"]
+  }
+}
+
+resource "google_compute_firewall" "bitmovin_rtmps_listener" {
+  count = var.live_rtmp ? 1 : 0
+
+  description   = "For RTMPS live streams"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-rtmps-listener"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = var.live_ingress_ipv4_network_blocks
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+}
+
+resource "google_compute_firewall" "bitmovin_srt_listener" {
+  count = var.live_srt ? 1 : 0
+
+  description   = "For SRT live streams"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-srt-listener"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = var.live_ingress_ipv4_network_blocks
+
+  allow {
+    protocol = "tcp"
+    ports    = ["2088"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["2088", "2089", "2090", "2091"]
+  }
+}
+
+resource "google_compute_firewall" "bitmovin_zixi_listener" {
+  count = var.live_zixi ? 1 : 0
+
+  description   = "For Zixi live streams"
+  name          = "${google_compute_network.bitmovin_vpc_network.name}-zixi-listener"
+  network       = google_compute_network.bitmovin_vpc_network.name
+  source_ranges = var.live_ingress_ipv4_network_blocks
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4444"]
+  }
+}

--- a/modules/gcp/rules.tf
+++ b/modules/gcp/rules.tf
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "bitmovin_allow_internal" {
 }
 
 resource "google_compute_firewall" "bitmovin_allow_ssh" {
-  description   = "For incoming commands from the bitmovin API to control the encoding"
+  description   = "For incoming commands from the Bitmovin API to control the encoding"
   name          = "${google_compute_network.bitmovin_vpc_network.name}-allow-ssh"
   network       = google_compute_network.bitmovin_vpc_network.name
   source_ranges = local.bitmovin_static_network_blocks

--- a/modules/gcp/terraform.tf
+++ b/modules/gcp/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "5.35.0"
+    }
+  }
+}

--- a/modules/gcp/terraform.tf
+++ b/modules/gcp/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.35.0"
+      version = "~> 5.35"
     }
   }
 }

--- a/modules/gcp/user.tf
+++ b/modules/gcp/user.tf
@@ -1,0 +1,17 @@
+# create service account
+resource "google_service_account" "bitmovin_account" {
+  account_id   = var.account_id
+  display_name = var.user_name
+}
+
+# assign project role
+resource "google_project_iam_member" "bitmovin_project" {
+  project = var.project_id
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.bitmovin_account.email}"
+}
+
+# create new access key
+resource "google_service_account_key" "mykey" {
+  service_account_id = google_service_account.bitmovin_account.id
+}

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -10,13 +10,13 @@ variable "project_id" {
 # Service account
 ##########################
 variable "account_id" {
-  description = "Account ID of the Bitmovin IAM user for Cloud Connect Encoding"
+  description = "Account ID of the Service Account user for Cloud Connect Encoding"
   type        = string
   default     = "bitmovin-cloud-connect-user"
 }
 
 variable "user_name" {
-  description = "Name of the Bitmovin IAM user for Cloud Connect Encoding"
+  description = "Name of the Service Account user for Cloud Connect Encoding"
   type        = string
   default     = "bitmovin-cloud-connect-user"
 }

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -1,0 +1,55 @@
+##########################
+# Project
+##########################
+variable "project_id" {
+  description = "Project ID of the Bitmovin project for Cloud Connect Encoding"
+  type        = string
+}
+
+##########################
+# Service account
+##########################
+variable "account_id" {
+  description = "Account ID of the Bitmovin IAM user for Cloud Connect Encoding"
+  type        = string
+  default     = "bitmovin-cloud-connect-user"
+}
+
+variable "user_name" {
+  description = "Name of the Bitmovin IAM user for Cloud Connect Encoding"
+  type        = string
+  default     = "bitmovin-cloud-connect-user"
+}
+
+##########################
+# VPC network
+##########################
+variable "network_name" {
+  description = "Auto-mode VPC network for Cloud Connect Encoding"
+  type        = string
+  default     = "bitmovin-cloud-connect"
+}
+
+variable "live_rtmp" {
+  description = "Whether to support RTMP live streams"
+  type        = bool
+  default     = false
+}
+
+variable "live_srt" {
+  description = "Whether to support SRT live streams"
+  type        = bool
+  default     = false
+}
+
+variable "live_zixi" {
+  description = "Whether to support Zixi live streams"
+  type        = bool
+  default     = false
+}
+
+variable "live_ingress_ipv4_network_blocks" {
+  description = "All IPv4"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
- adds basic GCP configuration for Cloud Connect according to https://developer.bitmovin.com/encoding/docs/using-bitmovin-cloud-connect-with-gcp
- splits module and example like existing AWS scripts
- updates README file to distinguish between AWS and GCP
- align firewall descriptions for AWS and GCP with Developer Docs tutorials