### PR TITLE
Updated gcp outputs

### DIFF
--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -4,10 +4,6 @@ output "project_id" {
   value = data.google_project.bitmovin_project.id
 }
 
-output "network_id" {
-  value = google_compute_network.bitmovin_vpc_network.name
-}
-
 output "network" {
   value = "/global/networks/${google_compute_network.bitmovin_vpc_network.name}"
 }
@@ -18,7 +14,9 @@ data "google_compute_network" "bitmovin-network" {
 }
 
 output "subnets" {
-  value = data.google_compute_network.bitmovin-network.subnetworks_self_links
+  value = [
+    for value in data.google_compute_network.bitmovin-network.subnetworks_self_links: regex(".*(\\/regions\\/.*)$", value)[0]
+  ]
 }
 
 output "service_account_email" {

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -8,6 +8,19 @@ output "network_id" {
   value = google_compute_network.bitmovin_vpc_network.name
 }
 
+output "network" {
+  value = "/global/networks/${google_compute_network.bitmovin_vpc_network.name}"
+}
+
+data "google_compute_network" "bitmovin-network" {
+  name = var.network_name
+  depends_on = [google_compute_network.bitmovin_vpc_network]
+}
+
+output "subnets" {
+  value = data.google_compute_network.bitmovin-network.subnetworks_self_links
+}
+
 output "service_account_email" {
   value = google_service_account.bitmovin_account.email
 }

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -4,27 +4,15 @@ output "project_id" {
   value = data.google_project.bitmovin_project.id
 }
 
-data "google_compute_network" "bitmovin_network" {
-  name = var.network_name
-}
-
 output "network_id" {
-  value = data.google_compute_network.bitmovin_network.name
-}
-
-data "google_service_account" "bitmovin_account" {
-  account_id = var.account_id
+  value = google_compute_network.bitmovin_vpc_network.name
 }
 
 output "service_account_email" {
-  value = data.google_service_account.bitmovin_account.email
-}
-
-data "google_service_account_key" "mykey" {
-  name = google_service_account_key.mykey.name
+  value = google_service_account.bitmovin_account.email
 }
 
 output "private_key" {
-  value     = data.google_service_account_key.mykey
+  value     = google_service_account_key.mykey.name
   sensitive = true
 }


### PR DESCRIPTION
We saw errors when trying to provision GCP infrastructure:

```
on ../../modules/gcp/outputs.tf line 7, in data "google_compute_network" "bitmovin_network":
 7: data "google_compute_network" "bitmovin_network" {

```
and 

```
on ../../modules/gcp/outputs.tf line 15, in data "google_service_account" "bitmovin_account":
15: data "google_service_account" "bitmovin_account" {
```

This was due to referencing [data sources](https://developer.hashicorp.com/terraform/language/data-sources) in the output section, that were not created yet. We now reference the actual resources in the output instead. 