### PR TITLE
Feature/gcp static ip permissions

### DIFF
--- a/modules/gcp/user.tf
+++ b/modules/gcp/user.tf
@@ -12,7 +12,7 @@ resource "google_project_iam_member" "bitmovin_project" {
 }
 
 resource "google_project_iam_member" "bitmovin_project-static-ip" {
-  count   = service_account_network_admin_permissions == true ? 1 : 0
+  count   = var.service_account_network_admin_permissions == true ? 1 : 0
   project = var.project_id
   role    = "roles/compute.networkAdmin"
   member  = "serviceAccount:${google_service_account.bitmovin_account.email}"

--- a/modules/gcp/user.tf
+++ b/modules/gcp/user.tf
@@ -11,6 +11,13 @@ resource "google_project_iam_member" "bitmovin_project" {
   member  = "serviceAccount:${google_service_account.bitmovin_account.email}"
 }
 
+resource "google_project_iam_member" "bitmovin_project-static-ip" {
+  count   = service_account_network_admin_permissions == true ? 1 : 0
+  project = var.project_id
+  role    = "roles/compute.networkAdmin"
+  member  = "serviceAccount:${google_service_account.bitmovin_account.email}"
+}
+
 # create new access key
 resource "google_service_account_key" "mykey" {
   service_account_id = google_service_account.bitmovin_account.id

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -21,6 +21,12 @@ variable "user_name" {
   default     = "bitmovin-cloud-connect-user"
 }
 
+variable "service_account_network_admin_permissions" {
+  description = "By setting this to true, the service Account will also get permissions to manage static IP addresses"
+  type        = bool
+  default     = false
+}
+
 ##########################
 # VPC network
 ##########################
@@ -50,6 +56,6 @@ variable "live_zixi" {
 
 variable "live_ingress_ipv4_network_blocks" {
   description = "All IPv4"
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
+  type = list(string)
+  default = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
Allow users to also give the Network Admin permissions, so the Service Account can create static IPs. As discussed with Lucky during a quick call. 