### PR TITLE
Added functionality to only select specific subnetworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore Intellij-specific files
+.idea

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The GCP module will create the following resources to enable running encoding jo
 - Creates a new Service Account
   - with the permissions of role `roles/compute.instanceAdmin.v1`
   - with an Access Key
-- Creates a new auto-mode VPC network
+- Creates a new VPC network
+  - In auto-mode if nothing is provided
+  - Only in certain regions if a list of objects with regions and cidr-ranges is provided
 - Creates the required firewall rules
 - Outputs:
   - Project ID

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -14,3 +14,13 @@ module "bitmovin_cloud_connect" {
   # For all possible input variables, please check:
   # Documentation: https://github.com/bitmovin/terraform-cloud-connect/blob/main/README.md#inputs
 }
+
+module "bitmovin_cloud_connect_with_specific_subnets" {
+  project_id = local.project_id
+  source = "git@github.com:bitmovin/terraform-cloud-connect.git//modules/gcp"
+
+  network_name = "selected-subnet-regions-only"
+  enabled_regions = [
+    {"region": "us-central1", "cidr": "10.128.0.0/20"}
+  ]
+}

--- a/modules/gcp/rules.tf
+++ b/modules/gcp/rules.tf
@@ -1,7 +1,7 @@
 locals {
   internal_network_blocks        = ["10.0.0.0/8"]
   bitmovin_static_network_blocks = ["104.199.97.13/32", "35.205.157.162/32"]
-  is_automode_vpc = lenght(var.enabled_regions) == 0 ? true : false
+  is_automode_vpc = length(var.enabled_regions) == 0 ? true : false
 }
 
 # enable Compute Engine API

--- a/modules/gcp/rules.tf
+++ b/modules/gcp/rules.tf
@@ -1,6 +1,7 @@
 locals {
   internal_network_blocks        = ["10.0.0.0/8"]
   bitmovin_static_network_blocks = ["104.199.97.13/32", "35.205.157.162/32"]
+  is_automode_vpc = lenght(var.enabled_regions) == 0 ? true : false
 }
 
 # enable Compute Engine API
@@ -12,8 +13,24 @@ resource "google_project_service" "compute-engine" {
 # create auto-mode VPC
 resource "google_compute_network" "bitmovin_vpc_network" {
   name = var.network_name
+  auto_create_subnetworks = local.is_automode_vpc
 
   depends_on = [google_project_service.compute-engine]
+}
+
+resource "google_compute_subnetwork" "bitmovin_vpc_subnetwork" {
+  for_each = {
+    for index, region in var.enabled_regions:
+    region.region => region
+  }
+
+  ip_cidr_range = each.value.cidr
+  name = "${var.network_name}-${each.value.region}-subnet"
+  network = google_compute_network.bitmovin_vpc_network.id
+  region = each.value.region
+  project = var.project_id
+  stack_type = "IPV4_ONLY"
+  purpose = "PRIVATE"
 }
 
 resource "google_compute_firewall" "bitmovin_allow_internal" {

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -36,6 +36,12 @@ variable "network_name" {
   default     = "bitmovin-cloud-connect"
 }
 
+variable "enabled_regions" {
+  description = "If the VPC should not be created in auto-mode, specify the regions and cidr-ranges"
+  type = list(object({region: string, cidr: string}))
+  default = []
+}
+
 variable "live_rtmp" {
   description = "Whether to support RTMP live streams"
   type        = bool


### PR DESCRIPTION
This PR adds the option to set only specific subnets when creating a GCP VPC, by passing a list of objects in the form
{region: "gcp-region", cidr: "0.0.0.0/0"}

This functionality was added, so we can also use this also for our internal testing-setup.