### PR TITLE
Added functionality to not use Bitmovin NAT IPs

### DIFF
--- a/modules/gcp/rules.tf
+++ b/modules/gcp/rules.tf
@@ -58,7 +58,7 @@ resource "google_compute_firewall" "bitmovin_allow_ssh" {
   description   = "For incoming commands from the Bitmovin API to control the encoding"
   name          = "${google_compute_network.bitmovin_vpc_network.name}-allow-ssh"
   network       = google_compute_network.bitmovin_vpc_network.name
-  source_ranges = local.bitmovin_static_network_blocks
+  source_ranges = var.enable_static_network_blocks == true ? local.bitmovin_static_network_blocks : ["0.0.0.0/0"]
 
   allow {
     protocol = "tcp"
@@ -70,7 +70,7 @@ resource "google_compute_firewall" "bitmovin_encoder_service" {
   description   = "For communication with the service that manages the encoding"
   name          = "${google_compute_network.bitmovin_vpc_network.name}-encoder-service"
   network       = google_compute_network.bitmovin_vpc_network.name
-  source_ranges = local.bitmovin_static_network_blocks
+  source_ranges = var.enable_static_network_blocks == true ? local.bitmovin_static_network_blocks : ["0.0.0.0/0"]
 
   allow {
     protocol = "tcp"
@@ -82,7 +82,7 @@ resource "google_compute_firewall" "bitmovin_encoder_service_https" {
   description   = "For HTTPS communication with the service that manages the encoding"
   name          = "${google_compute_network.bitmovin_vpc_network.name}-encoder-service-https"
   network       = google_compute_network.bitmovin_vpc_network.name
-  source_ranges = local.bitmovin_static_network_blocks
+  source_ranges = var.enable_static_network_blocks == true ? local.bitmovin_static_network_blocks : ["0.0.0.0/0"]
 
   allow {
     protocol = "tcp"

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -38,7 +38,7 @@ variable "network_name" {
 
 variable "enabled_regions" {
   description = "If the VPC should not be created in auto-mode, specify the regions and cidr-ranges"
-  type = list(object({region: string, cidr: string}))
+  type = list(object({ region : string, cidr : string }))
   default = []
 }
 
@@ -64,4 +64,10 @@ variable "live_ingress_ipv4_network_blocks" {
   description = "All IPv4"
   type = list(string)
   default = ["0.0.0.0/0"]
+}
+
+variable "enable_static_network_blocks" {
+  description = "Use the Bitmovin Static Network Blocks"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
Added additional functionality to explicitly disable our Cloud NAT Socks Proxies. This is necessary for one of our projects and should not be something that customers use, therefore it has to be disabled explicitly.