### PR TITLE
Adapt GCP outputs

### DIFF
--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -9,7 +9,7 @@ provider "google" {
 module "bitmovin_cloud_connect" {
   project_id = local.project_id
   source     = "../../modules/gcp" # local reference when you clone the repository
-  # source     = "github.com/bitmovin/terraform-cloud-connect/blob/main/modules/gcp" # remote GitHub reference
+  # source     = "github.com/bitmovin/terraform-cloud-connect//modules/gcp" # remote GitHub reference
 
   # For all possible input variables, please check:
   # Documentation: https://github.com/bitmovin/terraform-cloud-connect/blob/main/README.md#inputs
@@ -17,10 +17,10 @@ module "bitmovin_cloud_connect" {
 
 module "bitmovin_cloud_connect_with_specific_subnets" {
   project_id = local.project_id
-  source = "git@github.com:bitmovin/terraform-cloud-connect.git//modules/gcp"
+  source     = "github.com/bitmovin/terraform-cloud-connect//modules/gcp"
 
   network_name = "selected-subnet-regions-only"
   enabled_regions = [
-    {"region": "us-central1", "cidr": "10.128.0.0/20"}
+    { "region" : "us-central1", "cidr" : "10.128.0.0/20" }
   ]
 }

--- a/examples/gcp/outputs.tf
+++ b/examples/gcp/outputs.tf
@@ -6,14 +6,20 @@ output "service_account_email" {
   value = module.bitmovin_cloud_connect.service_account_email
 }
 
-output "private_key" {
-  value     = module.bitmovin_cloud_connect.private_key
-  sensitive = true
+# partially resembles JSON key file
+resource "local_file" "service_account_key_file" {
+  content = jsonencode({
+    "type" : "service_account"
+    "project_id" : local.project_id
+    "private_key" : jsondecode(base64decode(module.bitmovin_cloud_connect.private_key))["private_key"]
+    "client_email" : module.bitmovin_cloud_connect.service_account_email
+  })
+  filename = "${path.module}/${local.project_id}-${substr(jsondecode(base64decode(module.bitmovin_cloud_connect.private_key))["private_key_id"], 0, 12)}.json"
 }
 
 # output a message guiding users on handling the private key securely
 output "private_key_instructions" {
-  value = "To see your private key, run `terraform output -json`. Handle credentials carefully."
+  value = "To see your private key, open the generated JSON output file. Handle credentials carefully."
 }
 
 output "network_id" {

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -9,13 +9,13 @@ output "network" {
 }
 
 data "google_compute_network" "bitmovin-network" {
-  name = var.network_name
+  name       = var.network_name
   depends_on = [google_compute_network.bitmovin_vpc_network]
 }
 
 output "subnets" {
   value = [
-    for value in data.google_compute_network.bitmovin-network.subnetworks_self_links: regex(".*(\\/regions\\/.*)$", value)[0]
+    for value in data.google_compute_network.bitmovin-network.subnetworks_self_links : regex(".*(\\/regions\\/.*)$", value)[0]
   ]
 }
 
@@ -24,6 +24,6 @@ output "service_account_email" {
 }
 
 output "private_key" {
-  value     = google_service_account_key.mykey.name
+  value     = google_service_account_key.mykey.private_key
   sensitive = true
 }


### PR DESCRIPTION
Improve GCP output to create JSON output file to resemble the GCP service account key file partially:

```json
{"client_email":"...@....iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n","project_id":"...","type":"service_account"}
```